### PR TITLE
Add support for textonly in userlinks

### DIFF
--- a/action.php
+++ b/action.php
@@ -121,7 +121,7 @@ class action_plugin_authphpbb3 extends DokuWiki_Plugin {
         global $auth, $conf;
         $profile = '<a href="%s" class="interwiki iw_user" rel="nofollow" target="_blank">%s</a>';
 
-        if ($conf['showuseras'] !== 'username_link') {
+        if ($conf['showuseras'] !== 'username_link' || $event->data['textonly']) {
             return ;
         }
         if (empty($event->data['name'])) {


### PR DESCRIPTION
When the `textonly` option is enabled the userlink should not be a link but only the name.
For example in diff page, the select option displayed the link instead of the name.